### PR TITLE
Added 0.7 upgrade documentation for remote state references.

### DIFF
--- a/website/source/upgrade-guides/0-7.html.markdown
+++ b/website/source/upgrade-guides/0-7.html.markdown
@@ -134,6 +134,34 @@ resource "aws_instance" "example" {
 }
 ```
 
+References to remote state outputs has also changed, the `.output` keyword is no longer required.
+
+For example, a config like this:
+
+```
+resource "terraform_remote_state" "example" {
+  # ...
+}
+
+resource "aws_instance" "example" {
+  ami = "${terraform_remote_state.example.output.ami_id}"
+  # ...
+}
+```
+
+Would now look like this:
+
+```
+data "terraform_remote_state" "example" {
+  # ...
+}
+
+resource "aws_instance" "example" {
+  ami = "${data.terraform_remote_state.example.ami_id}"
+  # ...
+}
+```
+
 <a id="listmap"></a>
 
 ## Migrating to native lists and maps


### PR DESCRIPTION
**Reasoning for docs update**

Version 0.7 introduced changes to referencing remote state outputs, however these are not documented in the upgrade guide. See this comment from the [mailing list](https://groups.google.com/d/msg/terraform-tool/DKeUCnXrdkU/kTuf10vHAgAJ).

**Relevant Terraform version**

Affects documentation for version >= 0.7